### PR TITLE
Make an opportunity to extend user's info before registering

### DIFF
--- a/classes/UserManager.php
+++ b/classes/UserManager.php
@@ -146,6 +146,9 @@ class UserManager
             'phone' => $user_details->phone,
         ];
 
+        // Opportunity to extend user info
+        Event::fire('flynsarmy.sociallogin.extendUserBeforeRegister', [&$new_user]);
+
         $user = Auth::register($new_user, true);
         $this->attachAvatar($user, $user_details);
 


### PR DESCRIPTION
We need this, here is an usage example:
```php
Event::listen('flynsarmy.sociallogin.extendUserBeforeRegister', function (array &$userInfo) {
       $userInfo['gender'] = 'm';
       $userInfo['status'] = '0';
});
```