### PR TITLE
Session::flash() don't persist data

### DIFF
--- a/routes.php
+++ b/routes.php
@@ -21,6 +21,9 @@ Route::get(
 
             $provider = $provider_class::instance();
 
+            //Saving the session...
+            Session::save();
+
             return $provider->redirectToProvider();
         }
     ]


### PR DESCRIPTION
## Reproduction steps:
- Set 'f' and 's' parameters to the social provider link
- after login with the provider, the redirect success and fail are always '/' and 'login'

## The cause
Session in routes are not persisted by Session::flash() when a redirected is returned, so we need to manually Session::save();

Please, do this update in the OctoberCMS market place with thanks.